### PR TITLE
Set admin home directory group and permissions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,3 +20,7 @@ v0.1.0
 
 - Add option to disable kernel configuration. [drybjed]
 
+- Add variables to set admin account home directory group and permissions.
+  Admin account will be created only when not already present.
+  [drybjed]
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,12 @@ openvz_template_admin_home: '{{ "/home/" + openvz_template_admin_name }}'
 # Path to the home directory of admin account (system account)
 openvz_template_admin_system_home: '{{ ansible_local.root.home + "/" + openvz_template_admin_name }}'
 
+# Specify administrator account home directory group
+openvz_template_admin_home_group: '{{ openvz_template_admin_groups[0] }}'
+
+# Specify permissions for administrator account home directory
+openvz_template_admin_home_mode: '0750'
+
 # Comment / GECOS field added to the admin account
 openvz_template_admin_comment: 'System Administrator'
 

--- a/templates/usr/local/sbin/vzbootstrap-ansible.j2
+++ b/templates/usr/local/sbin/vzbootstrap-ansible.j2
@@ -67,6 +67,8 @@ openvz_template_admin_home="{{ openvz_template_admin_home }}"
 {% if openvz_template_sudo is defined and openvz_template_sudo %}
 openvz_template_sudo_group="{{ openvz_template_sudo_group }}"
 {% endif %}
+openvz_template_admin_home_group="{{ openvz_template_admin_home_group }}"
+openvz_template_admin_home_mode="{{ openvz_template_admin_home_mode }}"
 
 # Create required system groups if not present
 if [ \${{ '{' }}#openvz_template_admin_groups[@]} -ge 0 ] ; then
@@ -83,15 +85,24 @@ chmod 0440 /etc/sudoers.d/\${openvz_template_sudo_group}
 {% endif %}
 # Create administrator account
 {% if openvz_template_admin_system is defined and openvz_template_admin_system %}
-getent passwd \${openvz_template_admin_name} || useradd --system --user-group --groups \${openvz_template_admin_groups_useradd} --create-home --home \${openvz_template_admin_home} --comment "\${openvz_template_admin_comment}" --shell \${openvz_template_admin_shell} \${openvz_template_admin_name}
-{% else %}
-getent passwd \${openvz_template_admin_name} || adduser --disabled-password --home \${openvz_template_admin_home} --gecos "\${openvz_template_admin_comment}" --shell \${openvz_template_admin_shell} \${openvz_template_admin_name}
-
-if [ \${{ '{' }}#openvz_template_admin_groups[@]} -ge 0 ] ; then
-    for system_group in \${openvz_template_admin_groups[@]} ; do
-        adduser \${openvz_template_admin_name} \${system_group}
-    done
+if ! getent passwd \${openvz_template_admin_name} > /dev/null ; then
+    useradd --system --user-group --groups \${openvz_template_admin_groups_useradd} --create-home --home \${openvz_template_admin_home} --comment "\${openvz_template_admin_comment}" --shell \${openvz_template_admin_shell} \${openvz_template_admin_name}
+    chgrp \${openvz_template_admin_home_group} \${openvz_template_admin_home}
+    chmod \${openvz_template_admin_home_mode} \${openvz_template_admin_home}
 fi
+{% else %}
+if ! getent passwd \${openvz_template_admin_name} > /dev/null ; then
+    adduser --disabled-password --home \${openvz_template_admin_home} --gecos "\${openvz_template_admin_comment}" --shell \${openvz_template_admin_shell} \${openvz_template_admin_name}
+    chgrp \${openvz_template_admin_home_group} \${openvz_template_admin_home}
+    chmod \${openvz_template_admin_home_mode} \${openvz_template_admin_home}
+
+    if [ \${{ '{' }}#openvz_template_admin_groups[@]} -ge 0 ] ; then
+        for system_group in \${openvz_template_admin_groups[@]} ; do
+            adduser \${openvz_template_admin_name} \${system_group}
+        done
+    fi
+fi
+
 {% endif %}
 
 {% endif %}
@@ -107,9 +118,11 @@ if [ -n "\${openvz_template_admin_sshkeys}" ] ; then
     echo "\${openvz_template_admin_sshkeys}" > /root/.ssh/authorized_keys
 
 {% if openvz_template_admin is defined and openvz_template_admin %}
-    mkdir -p -m 700 \${openvz_template_admin_home}/.ssh
-    echo "\${openvz_template_admin_sshkeys}" > \${openvz_template_admin_home}/.ssh/authorized_keys
-    chown -R \${openvz_template_admin_name}:\${openvz_template_admin_name} \${openvz_template_admin_home}/.ssh
+    admin_home="\$(getent passwd \${lxc_template_admin_name} | cut -d: -f6)"
+    mkdir -p -m 700 \${admin_home}/.ssh
+    touch \${admin_home}/.ssh/authorized_keys
+    echo "\${openvz_template_admin_sshkeys}" >> \${admin_home}/.ssh/authorized_keys
+    chown -R \${openvz_template_admin_name}:\${openvz_template_admin_name} \${admin_home}/.ssh
 
 {% endif %}
 fi


### PR DESCRIPTION
Add variables to set admin account home directory group and permissions. Admin account will be created only when not already present.