### PR TITLE
ansible_ssh_user -> ansible_user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,7 +92,7 @@ openvz_template_admin: True
 openvz_template_admin_system: True
 
 # Name of default admin account created by the bootstrap script
-openvz_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else lookup("env","USER") }}'
+openvz_template_admin_name: '{{ ansible_user if ansible_user != "root" else lookup("env","USER") }}'
 
 # List of system groups to which admin account will be added by default
 openvz_template_admin_groups: [ 'admins', 'staff', 'adm' ]


### PR DESCRIPTION
Since Ansible 2.0.0 ansible_ssh_user is replaced by ansible_user