### PR TITLE
ansible_ssh_user -> ansible_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ on Debian Wheezy/Jessie and LXC.
 
 ### Installation
 
-This role requires at least Ansible `v1.7.0`. To install it, run:
+This role requires at least Ansible `v2.0.0`. To install it, run:
 
     ansible-galaxy install debops.openvz
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,7 +92,7 @@ openvz_template_admin: True
 openvz_template_admin_system: True
 
 # Name of default admin account created by the bootstrap script
-openvz_template_admin_name: '{{ ansible_ssh_user if ansible_ssh_user != "root" else lookup("env","USER") }}'
+openvz_template_admin_name: '{{ ansible_user if ansible_user != "root" else lookup("env","USER") }}'
 
 # List of system groups to which admin account will be added by default
 openvz_template_admin_groups: [ 'admins', 'staff', 'adm' ]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ galaxy_info:
   description: 'Set up OpenVZ environment on Debian Wheezy'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.0.0'
   platforms:
   - name: Debian
     versions:


### PR DESCRIPTION
Since Ansible 2.0.0 ansible_ssh_user is replaced by ansible_user. As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required